### PR TITLE
base: Add three-fingers-swipe to screenshot [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4710,6 +4710,12 @@ public final class Settings {
         public static final Validator SHOW_VOLTE_ICON_VALIDATOR = BOOLEAN_VALIDATOR;
 
         /**
+         * Three Finger Gesture from Oppo
+         * @hide
+         */
+        public static final String THREE_FINGER_GESTURE = "three_finger_gesture";
+
+        /**
          * Settings to backup. This is here so that it's in the same place as the settings
          * keys and easy to update.
          *

--- a/services/core/java/com/android/server/policy/OPGesturesListener.java
+++ b/services/core/java/com/android/server/policy/OPGesturesListener.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2015 The Euphoria-OS Project
+ * Copyright (C) 2015 The SudaMod Project
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.server.policy;
+
+import android.content.Context;
+import android.util.Slog;
+import android.view.MotionEvent;
+import android.view.WindowManagerPolicyConstants.PointerEventListener;
+
+public class OPGesturesListener implements PointerEventListener {
+    private static final String TAG = "OPGestures";
+    private static final boolean DEBUG = false;
+    private static final int NUM_POINTER_SCREENSHOT = 3;
+    private static final long SWIPE_TIMEOUT_MS = 500;
+    private static final int MAX_TRACKED_POINTERS = 32;
+    private static final int UNTRACKED_POINTER = -1;
+    private static final int THREE_SWIPE_DISTANCE = 350;
+    private final int GESTURE_THREE_SWIPE_MASK = 15;
+    private final int POINTER_1_MASK = 2;
+    private final int POINTER_2_MASK = 4;
+    private final int POINTER_3_MASK = 8;
+    private final int POINTER_NONE_MASK = 1;
+    private final Callbacks mCallbacks;
+    private final int[] mDownPointerId = new int[MAX_TRACKED_POINTERS];
+    private final float[] mDownX = new float[MAX_TRACKED_POINTERS];
+    private final float[] mDownY = new float[MAX_TRACKED_POINTERS];
+    private final long[] mDownTime = new long[MAX_TRACKED_POINTERS];
+    private int mDownPointers;
+    private boolean mSwipeFireable = false;
+    private int mSwipeMask = 1;
+
+    public OPGesturesListener(Context paramContext, Callbacks callbacks) {
+        mCallbacks = checkNull("callbacks", callbacks);
+    }
+
+    private static <T> T checkNull(String name, T arg) {
+        if (arg == null) {
+            throw new IllegalArgumentException(name + " must not be null");
+        }
+        return arg;
+    }
+
+    @Override
+    public void onPointerEvent(MotionEvent event) {
+        switch (event.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+                mSwipeFireable = true;
+                mDownPointers = 0;
+                captureDown(event, 0);
+                break;
+            case MotionEvent.ACTION_POINTER_DOWN:
+                captureDown(event, event.getActionIndex());
+                break;
+            case MotionEvent.ACTION_MOVE:
+                if (DEBUG) Slog.d(TAG, "count3" + event.getPointerCount());
+                if (mSwipeFireable) {
+                    detectSwipe(event);
+                }
+                break;
+            case MotionEvent.ACTION_UP:
+                if (mSwipeMask == GESTURE_THREE_SWIPE_MASK) {
+                    mSwipeMask = 1;
+                    mCallbacks.onSwipeThreeFinger();
+                }
+                break;
+            case MotionEvent.ACTION_CANCEL:
+                mSwipeFireable = false;
+                break;
+            case MotionEvent.ACTION_POINTER_UP:
+                break;
+            default:
+                if (DEBUG) Slog.d(TAG, "Ignoring " + event);
+        }
+    }
+
+    private void captureDown(MotionEvent event, int pointerIndex) {
+        final int pointerId = event.getPointerId(pointerIndex);
+        final int i = findIndex(pointerId);
+        final int pointerCount  = event.getPointerCount();
+        if (DEBUG) Slog.d(TAG, "pointer " + pointerId +
+                " down pointerIndex=" + pointerIndex + " trackingIndex=" + i);
+        if (i != UNTRACKED_POINTER) {
+            mDownX[i] = event.getX(pointerIndex);
+            mDownY[i] = event.getY(pointerIndex);
+            mDownTime[i] = event.getEventTime();
+            if (DEBUG) Slog.d(TAG, "pointer " + pointerId +
+                    " down x=" + mDownX[i] + " y=" + mDownY[i]);
+        }
+        if (pointerCount == NUM_POINTER_SCREENSHOT) {
+            mSwipeFireable = true;
+            return;
+        }
+        mSwipeFireable = false;
+    }
+
+    private int findIndex(int pointerId) {
+        for (int i = 0; i < mDownPointers; i++) {
+            if (mDownPointerId[i] == pointerId) {
+                return i;
+            }
+        }
+        if (mDownPointers == MAX_TRACKED_POINTERS || pointerId == MotionEvent.INVALID_POINTER_ID) {
+            return UNTRACKED_POINTER;
+        }
+        mDownPointerId[mDownPointers++] = pointerId;
+        return mDownPointers - 1;
+    }
+
+    private void detectSwipe(MotionEvent move) {
+        move.getHistorySize();
+        final int pointerCount = move.getPointerCount();
+        for (int p = 0; p < pointerCount; p++) {
+            final int pointerId = move.getPointerId(p);
+            final int i = findIndex(pointerId);
+            if (i != UNTRACKED_POINTER) {
+                detectSwipe(i, move.getEventTime(), move.getX(p), move.getY(p));
+            }
+        }
+    }
+
+    private void detectSwipe(int i, long time, float x, float y) {
+        final float fromX = mDownX[i];
+        final float fromY = mDownY[i];
+        final long elapsed = time - mDownTime[i];
+        if (DEBUG) Slog.d(TAG, "pointer " + mDownPointerId[i]
+                + " moved (" + fromX + "->" + x + "," + fromY + "->" + y + ") in " + elapsed);
+        if (mSwipeMask < GESTURE_THREE_SWIPE_MASK
+                && y > fromY + THREE_SWIPE_DISTANCE
+                && elapsed < SWIPE_TIMEOUT_MS) {
+            mSwipeMask |= 1 << i + 1;
+            if (DEBUG) Slog.d(TAG, "swipe mask = " + mSwipeMask);
+        }
+    }
+
+    interface Callbacks {
+        void onSwipeThreeFinger();
+    }
+}

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -217,6 +217,7 @@ import com.android.internal.policy.PhoneWindow;
 import com.android.internal.statusbar.IStatusBarService;
 import com.android.internal.util.aosap.aosapUtils;
 import com.android.internal.util.ArrayUtils;
+import com.android.internal.util.ScreenshotHelper;
 import com.android.server.ExtconStateObserver;
 import com.android.server.ExtconUEventObserver;
 import com.android.server.GestureLauncherService;
@@ -622,6 +623,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     boolean mHavePendingMediaKeyRepeatWithWakeLock;
 
     private int mCurrentUserId;
+    private boolean haveEnableGesture = false;
 
     // Maps global key codes to the components that will handle them.
     private GlobalKeyManager mGlobalKeyManager;
@@ -706,6 +708,7 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     private static final int MSG_CLEAR_PROXIMITY = 51;
     private static final int MSG_DISPATCH_VOLKEY_SKIP_TRACK = 52;
 
+    private OPGesturesListener mOPGestures;
     private class PolicyHandler extends Handler {
         @Override
         public void handleMessage(Message msg) {
@@ -934,6 +937,9 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     UserHandle.USER_ALL);
             resolver.registerContentObserver(Settings.System.getUriFor(
                     Settings.System.DOZE_TRIGGER_DOUBLETAP), false, this,
+                    UserHandle.USER_ALL);
+            resolver.registerContentObserver(Settings.System.getUriFor(
+                    Settings.System.THREE_FINGER_GESTURE), false, this,
                     UserHandle.USER_ALL);
             updateSettings();
         }
@@ -2016,6 +2022,12 @@ public class PhoneWindowManager implements WindowManagerPolicy {
         }
 
         mHandler = new PolicyHandler();
+        mOPGestures = new OPGesturesListener(context, new OPGesturesListener.Callbacks() {
+            @Override
+            public void onSwipeThreeFinger() {
+                mHandler.post(mScreenshotRunnable);
+            }
+        });
         mWakeGestureListener = new MyWakeGestureListener(mContext, mHandler);
         mSettingsObserver = new SettingsObserver(mHandler);
         mSettingsObserver.observe();
@@ -2198,6 +2210,18 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                 .newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "ProximityWakeLock");
     }
 
+    private void enableSwipeThreeFingerGesture(boolean enable){
+        if (enable) {
+            if (haveEnableGesture) return;
+            haveEnableGesture = true;
+            mWindowManagerFuncs.registerPointerEventListener(mOPGestures, DEFAULT_DISPLAY);
+        } else {
+            if (!haveEnableGesture) return;
+            haveEnableGesture = false;
+            mWindowManagerFuncs.unregisterPointerEventListener(mOPGestures, DEFAULT_DISPLAY);
+        }
+    }
+
     /**
      * Read values from config.xml that may be overridden depending on
      * the configuration of the device.
@@ -2262,6 +2286,11 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                     .getBoolean(com.android.internal.R.bool.config_volumeHushGestureEnabled)) {
                 mRingerToggleChord = Settings.Secure.VOLUME_HUSH_OFF;
             }
+
+            //Three Finger Gesture
+            boolean threeFingerGesture = Settings.System.getIntForUser(resolver,
+                    Settings.System.THREE_FINGER_GESTURE, 0, UserHandle.USER_CURRENT) == 1;
+            enableSwipeThreeFingerGesture(threeFingerGesture);
 
             // Configure wake gesture.
             boolean wakeGestureEnabledSetting = Settings.Secure.getIntForUser(resolver,


### PR DESCRIPTION
The feature is ported from Oppo ColorOS.
With the options on, users can swipe down
on the screen to have a screenshot.

original smali port by: wuxianlin

Signed-off-by: ZeNiXxX <zenixxx.havoc@gmail.com>

 Conflicts:
	core/java/android/provider/Settings.java
	services/core/java/com/android/server/policy/PhoneWindowManager.java

Signed-off-by: Ali Hasan <ahb7671@gmail.com>