### PR TITLE
SystemUI: Allow overlaying max notification icons

### DIFF
--- a/packages/SystemUI/res/values/aosap_config.xml
+++ b/packages/SystemUI/res/values/aosap_config.xml
@@ -16,4 +16,8 @@
 <resources>
     <!-- Allow devices override audio panel location to the left side -->
     <bool name="config_audioPanelOnLeftSide">false</bool>
+
+    <!-- Max visible notification icons -->
+    <integer name="config_maxVisibleNotificationIcons">4</integer>
+    <integer name="config_maxVisibleNotificationIconsOnLock">5</integer>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationIconContainer.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationIconContainer.java
@@ -128,8 +128,10 @@ public class NotificationIconContainer extends AlphaOptimizedFrameLayout {
         }
     }.setDuration(CONTENT_FADE_DURATION);
 
-    private static final int MAX_VISIBLE_ICONS_ON_LOCK = 5;
-    public static final int MAX_STATIC_ICONS = 4;
+    private final int MAX_VISIBLE_ICONS_ON_LOCK =
+            getResources().getInteger(R.integer.config_maxVisibleNotificationIconsOnLock);
+    public final int MAX_STATIC_ICONS =
+            getResources().getInteger(R.integer.config_maxVisibleNotificationIcons);
     private static final int MAX_DOTS = 1;
 
     private boolean mIsStaticLayout = true;


### PR DESCRIPTION
* I believe there are devices in this world that can fit
  more than 4 notification icons.

Signed-off-by: Ali Hasan <ahb7671@gmail.com>